### PR TITLE
ver 5.1.20.4 - API key in add-on settings

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.youtube" name="YouTube" version="5.1.20.3" provider-name="bromix">
+<addon id="plugin.video.youtube" name="YouTube" version="5.1.20.4" provider-name="bromix">
 	<requires>
 		<import addon="xbmc.python" version="2.1.0"/>
 	</requires>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+5.1.20.4 (2016-03-05)
+[add] API Key in add-on settings
+[upd] All string.po for new API Key functionality. New entries in language string.po files not translated from English.
+
 5.1.20.3 (2016-03-04)
 [fix] All Key changed with YouTube TV
 

--- a/resources/language/Bulgarian/strings.po
+++ b/resources/language/Bulgarian/strings.po
@@ -225,6 +225,28 @@ msgctxt "#30120"
 msgid "Clear"
 msgstr "Изчисти"
 
+#YouTube
+#empty strings from id 30121 to 30199
+
+msgctxt "#30200"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30201"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30202"
+msgid "API Id"
+msgstr ""
+
+msgctxt "#30203"
+msgid "API Secret"
+msgstr ""
+
+#YouTube
+#empty strings from id 30204 to 30499
+
 msgctxt "#30500"
 msgid "Channels"
 msgstr "Канали"

--- a/resources/language/Chinese (Traditional)/strings.po
+++ b/resources/language/Chinese (Traditional)/strings.po
@@ -225,6 +225,28 @@ msgctxt "#30120"
 msgid "Clear"
 msgstr "清除"
 
+#YouTube
+#empty strings from id 30121 to 30199
+
+msgctxt "#30200"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30201"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30202"
+msgid "API Id"
+msgstr ""
+
+msgctxt "#30203"
+msgid "API Secret"
+msgstr ""
+
+#YouTube
+#empty strings from id 30204 to 30499
+
 msgctxt "#30500"
 msgid "Channels"
 msgstr "頻道"

--- a/resources/language/Czech/strings.po
+++ b/resources/language/Czech/strings.po
@@ -225,6 +225,28 @@ msgctxt "#30120"
 msgid "Clear"
 msgstr "Vyčistit"
 
+#YouTube
+#empty strings from id 30121 to 30199
+
+msgctxt "#30200"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30201"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30202"
+msgid "API Id"
+msgstr ""
+
+msgctxt "#30203"
+msgid "API Secret"
+msgstr ""
+
+#YouTube
+#empty strings from id 30204 to 30499
+
 msgctxt "#30500"
 msgid "Channels"
 msgstr "Kanály"

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -235,7 +235,26 @@ msgid "Clear"
 msgstr ""
 
 #YouTube
-#empty strings from id 30121 to 30499
+#empty strings from id 30121 to 30199
+
+msgctxt "#30200"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30201"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30202"
+msgid "API Id"
+msgstr ""
+
+msgctxt "#30203"
+msgid "API Secret"
+msgstr ""
+
+#YouTube
+#empty strings from id 30204 to 30499
 
 msgctxt "#30500"
 msgid "Channels"
@@ -436,3 +455,4 @@ msgstr ""
 msgctxt "#30549"
 msgid "No videos streams found"
 msgstr ""
+

--- a/resources/language/French/strings.po
+++ b/resources/language/French/strings.po
@@ -225,6 +225,28 @@ msgctxt "#30120"
 msgid "Clear"
 msgstr "Nettoyer"
 
+#YouTube
+#empty strings from id 30121 to 30199
+
+msgctxt "#30200"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30201"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30202"
+msgid "API Id"
+msgstr ""
+
+msgctxt "#30203"
+msgid "API Secret"
+msgstr ""
+
+#YouTube
+#empty strings from id 30204 to 30499
+
 msgctxt "#30500"
 msgid "Channels"
 msgstr "Chaînes"

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -225,6 +225,28 @@ msgctxt "#30120"
 msgid "Clear"
 msgstr "Leeren"
 
+#YouTube
+#empty strings from id 30121 to 30199
+
+msgctxt "#30200"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30201"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30202"
+msgid "API Id"
+msgstr ""
+
+msgctxt "#30203"
+msgid "API Secret"
+msgstr ""
+
+#YouTube
+#empty strings from id 30204 to 30499
+
 msgctxt "#30500"
 msgid "Channels"
 msgstr "Kanäle"

--- a/resources/language/Hebrew/strings.po
+++ b/resources/language/Hebrew/strings.po
@@ -225,6 +225,28 @@ msgctxt "#30120"
 msgid "Clear"
 msgstr "נקה"
 
+#YouTube
+#empty strings from id 30121 to 30199
+
+msgctxt "#30200"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30201"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30202"
+msgid "API Id"
+msgstr ""
+
+msgctxt "#30203"
+msgid "API Secret"
+msgstr ""
+
+#YouTube
+#empty strings from id 30204 to 30499
+
 msgctxt "#30500"
 msgid "Channels"
 msgstr "ערוצים"

--- a/resources/language/Hungarian/strings.po
+++ b/resources/language/Hungarian/strings.po
@@ -225,6 +225,28 @@ msgctxt "#30120"
 msgid "Clear"
 msgstr ""
 
+#YouTube
+#empty strings from id 30121 to 30199
+
+msgctxt "#30200"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30201"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30202"
+msgid "API Id"
+msgstr ""
+
+msgctxt "#30203"
+msgid "API Secret"
+msgstr ""
+
+#YouTube
+#empty strings from id 30204 to 30499
+
 msgctxt "#30500"
 msgid "Channels"
 msgstr "Csatornák"

--- a/resources/language/Italian/strings.po
+++ b/resources/language/Italian/strings.po
@@ -225,6 +225,28 @@ msgctxt "#30120"
 msgid "Clear"
 msgstr ""
 
+#YouTube
+#empty strings from id 30121 to 30199
+
+msgctxt "#30200"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30201"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30202"
+msgid "API Id"
+msgstr ""
+
+msgctxt "#30203"
+msgid "API Secret"
+msgstr ""
+
+#YouTube
+#empty strings from id 30204 to 30499
+
 msgctxt "#30500"
 msgid "Channels"
 msgstr "Canali"

--- a/resources/language/Korean/strings.po
+++ b/resources/language/Korean/strings.po
@@ -225,6 +225,28 @@ msgctxt "#30120"
 msgid "Clear"
 msgstr "Clear"
 
+#YouTube
+#empty strings from id 30121 to 30199
+
+msgctxt "#30200"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30201"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30202"
+msgid "API Id"
+msgstr ""
+
+msgctxt "#30203"
+msgid "API Secret"
+msgstr ""
+
+#YouTube
+#empty strings from id 30204 to 30499
+
 msgctxt "#30500"
 msgid "Channels"
 msgstr "채널"

--- a/resources/language/Polish/strings.po
+++ b/resources/language/Polish/strings.po
@@ -225,6 +225,28 @@ msgctxt "#30120"
 msgid "Clear"
 msgstr "Wyczyść"
 
+#YouTube
+#empty strings from id 30121 to 30199
+
+msgctxt "#30200"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30201"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30202"
+msgid "API Id"
+msgstr ""
+
+msgctxt "#30203"
+msgid "API Secret"
+msgstr ""
+
+#YouTube
+#empty strings from id 30204 to 30499
+
 msgctxt "#30500"
 msgid "Channels"
 msgstr "Kanały"

--- a/resources/language/Portuguese (Brazil)/strings.po
+++ b/resources/language/Portuguese (Brazil)/strings.po
@@ -225,6 +225,28 @@ msgctxt "#30120"
 msgid "Clear"
 msgstr "Limpar"
 
+#YouTube
+#empty strings from id 30121 to 30199
+
+msgctxt "#30200"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30201"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30202"
+msgid "API Id"
+msgstr ""
+
+msgctxt "#30203"
+msgid "API Secret"
+msgstr ""
+
+#YouTube
+#empty strings from id 30204 to 30499
+
 msgctxt "#30500"
 msgid "Channels"
 msgstr "Canais"

--- a/resources/language/Portuguese/strings.po
+++ b/resources/language/Portuguese/strings.po
@@ -225,6 +225,28 @@ msgctxt "#30120"
 msgid "Clear"
 msgstr ""
 
+#YouTube
+#empty strings from id 30121 to 30199
+
+msgctxt "#30200"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30201"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30202"
+msgid "API Id"
+msgstr ""
+
+msgctxt "#30203"
+msgid "API Secret"
+msgstr ""
+
+#YouTube
+#empty strings from id 30204 to 30499
+
 msgctxt "#30500"
 msgid "Channels"
 msgstr "Canais"

--- a/resources/language/Romanian/strings.po
+++ b/resources/language/Romanian/strings.po
@@ -225,6 +225,28 @@ msgctxt "#30120"
 msgid "Clear"
 msgstr "Curăță"
 
+#YouTube
+#empty strings from id 30121 to 30199
+
+msgctxt "#30200"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30201"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30202"
+msgid "API Id"
+msgstr ""
+
+msgctxt "#30203"
+msgid "API Secret"
+msgstr ""
+
+#YouTube
+#empty strings from id 30204 to 30499
+
 msgctxt "#30500"
 msgid "Channels"
 msgstr "Canale"

--- a/resources/language/Russian/strings.po
+++ b/resources/language/Russian/strings.po
@@ -225,6 +225,28 @@ msgctxt "#30120"
 msgid "Clear"
 msgstr "Очистить"
 
+#YouTube
+#empty strings from id 30121 to 30199
+
+msgctxt "#30200"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30201"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30202"
+msgid "API Id"
+msgstr ""
+
+msgctxt "#30203"
+msgid "API Secret"
+msgstr ""
+
+#YouTube
+#empty strings from id 30204 to 30499
+
 msgctxt "#30500"
 msgid "Channels"
 msgstr "Каналы"

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -225,6 +225,28 @@ msgctxt "#30120"
 msgid "Clear"
 msgstr ""
 
+#YouTube
+#empty strings from id 30121 to 30199
+
+msgctxt "#30200"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30201"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30202"
+msgid "API Id"
+msgstr ""
+
+msgctxt "#30203"
+msgid "API Secret"
+msgstr ""
+
+#YouTube
+#empty strings from id 30204 to 30499
+
 msgctxt "#30500"
 msgid "Channels"
 msgstr "Canales"

--- a/resources/language/Ukrainian/strings.po
+++ b/resources/language/Ukrainian/strings.po
@@ -225,6 +225,28 @@ msgctxt "#30120"
 msgid "Clear"
 msgstr "Очистити"
 
+#YouTube
+#empty strings from id 30121 to 30199
+
+msgctxt "#30200"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30201"
+msgid "API Key"
+msgstr ""
+
+msgctxt "#30202"
+msgid "API Id"
+msgstr ""
+
+msgctxt "#30203"
+msgid "API Secret"
+msgstr ""
+
+#YouTube
+#empty strings from id 30204 to 30499
+
 msgctxt "#30500"
 msgid "Channels"
 msgstr "Канали"

--- a/resources/lib/youtube/client/login_client.py
+++ b/resources/lib/youtube/client/login_client.py
@@ -1,13 +1,18 @@
 __author__ = 'bromix'
 
+import xbmcaddon
 import time
 import urlparse
 
 from resources.lib.kodion import simple_requests as requests
 from resources.lib.youtube.youtube_exceptions import LoginException
 
-# Kodi 17 support by Uukrul
+addon = xbmcaddon.Addon()
+api_key = addon.getSetting('youtube.api.key')
+api_id = addon.getSetting('youtube.api.id')
+api_secret = addon.getSetting('youtube.api.secret')
 
+# Kodi 17 support by Uukrul
 
 class LoginClient(object):
     CONFIGS = {
@@ -21,52 +26,52 @@ class LoginClient(object):
         'youtube-for-kodi-quota': {
             'token-allowed': False,
             'system': 'All',
-            'key': 'AIzaSyAd-YEOqZz9nXVzGtn3KWzYLbLaajhqIDA',
-            'id': '861556708454-d6dlm3lh05idd8npek18k6be8ba3oc68.apps.googleusercontent.com',
-            'secret': 'SboVhoG9s0rNafixCSGGKXAT'
+            'key': '%s' % api_key,
+            'id': '%s.apps.googleusercontent.com' % api_id,
+            'secret': '%s' % api_secret
         },
         'youtube-for-kodi-fallback': {
             'token-allowed': False,
             'system': 'Fallback!',
-            'key': 'AIzaSyAd-YEOqZz9nXVzGtn3KWzYLbLaajhqIDA',
-            'id': '861556708454-d6dlm3lh05idd8npek18k6be8ba3oc68.apps.googleusercontent.com',
-            'secret': 'SboVhoG9s0rNafixCSGGKXAT'
+            'key': '%s' % api_key,
+            'id': '%s.apps.googleusercontent.com' % api_id,
+            'secret': '%s' % api_secret
         },
         'youtube-for-kodi-12': {
             'system': 'Frodo',
-            'key': 'AIzaSyAd-YEOqZz9nXVzGtn3KWzYLbLaajhqIDA',
-            'id': '861556708454-d6dlm3lh05idd8npek18k6be8ba3oc68.apps.googleusercontent.com',
-            'secret': 'SboVhoG9s0rNafixCSGGKXAT'
+            'key': '%s' % api_key,
+            'id': '%s.apps.googleusercontent.com' % api_id,
+            'secret': '%s' % api_secret
         },
         'youtube-for-kodi-13': {
             'system': 'Gotham',
-            'key': 'AIzaSyAd-YEOqZz9nXVzGtn3KWzYLbLaajhqIDA',
-            'id': '861556708454-d6dlm3lh05idd8npek18k6be8ba3oc68.apps.googleusercontent.com',
-            'secret': 'SboVhoG9s0rNafixCSGGKXAT'
+            'key': '%s' % api_key,
+            'id': '%s.apps.googleusercontent.com' % api_id,
+            'secret': '%s' % api_secret
         },
         'youtube-for-kodi-14': {
             'system': 'Helix',
-            'key': 'AIzaSyAd-YEOqZz9nXVzGtn3KWzYLbLaajhqIDA',
-            'id': '861556708454-d6dlm3lh05idd8npek18k6be8ba3oc68.apps.googleusercontent.com',
-            'secret': 'SboVhoG9s0rNafixCSGGKXAT'
+            'key': '%s' % api_key,
+            'id': '%s.apps.googleusercontent.com' % api_id,
+            'secret': '%s' % api_secret
         },
         'youtube-for-kodi-15': {
             'system': 'Isengard',
-            'key': 'AIzaSyAd-YEOqZz9nXVzGtn3KWzYLbLaajhqIDA',
-            'id': '861556708454-d6dlm3lh05idd8npek18k6be8ba3oc68.apps.googleusercontent.com',
-            'secret': 'SboVhoG9s0rNafixCSGGKXAT'
+            'key': '%s' % api_key,
+            'id': '%s.apps.googleusercontent.com' % api_id,
+            'secret': '%s' % api_secret
         },
         'youtube-for-kodi-16': {
             'system': 'Jarvis',
-            'key': 'AIzaSyAd-YEOqZz9nXVzGtn3KWzYLbLaajhqIDA',
-            'id': '861556708454-d6dlm3lh05idd8npek18k6be8ba3oc68.apps.googleusercontent.com',
-            'secret': 'SboVhoG9s0rNafixCSGGKXAT'
+            'key': '%s' % api_key,
+            'id': '%s.apps.googleusercontent.com' % api_id,
+            'secret': '%s' % api_secret
         },
             'youtube-for-kodi-17': {
             'system': 'Krypton',
-            'key': 'AIzaSyAd-YEOqZz9nXVzGtn3KWzYLbLaajhqIDA',
-            'id': '861556708454-d6dlm3lh05idd8npek18k6be8ba3oc68.apps.googleusercontent.com',
-            'secret': 'SboVhoG9s0rNafixCSGGKXAT'
+            'key': '%s' % api_key,
+            'id': '%s.apps.googleusercontent.com' % api_id,
+            'secret': '%s' % api_secret
         }
     }
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -43,4 +43,11 @@
         <setting type="sep" />
         <setting id="youtube.language" type="text" label="30523" enable="false" default="en-US"/>
     </category>
+    
+    <!-- personal api key -->
+    <category label="30200">
+        <setting id="youtube.api.key" type="text" label="30201" default="AIzaSyAd-YEOqZz9nXVzGtn3KWzYLbLaajhqIDA"/>
+        <setting id="youtube.api.id" type="text" label="30202" default="861556708454-d6dlm3lh05idd8npek18k6be8ba3oc68"/>
+        <setting id="youtube.api.secret" type="text" label="30203" default="SboVhoG9s0rNafixCSGGKXAT"/>
+    </category>
 </settings>


### PR DESCRIPTION
API key is now configurable from add-on settings. Users that have valid API key can now enter their key from add-on settings dialog. API Key from version 5.1.20.3 is never lost if end-user makes a change since version 5.1.20.3 API key is default value in settings.xml file. The youtube-tv key in login_client.py cannot be changed. Only kodi-quota, kodi-fallback and kodi-xx version will change when end-user enters their API key. If end-user enters a non-working key or makes a mistake when entering their key, the youtube add-on will continue to work if the end-user selects 'Default' button in the add-on settings since that will activate the default API key.

This new feature is safer for less experienced end-users since they can enter a valid API key without any python programming knowledge. All end-users who are currently using their own API key will like this new change as well because they will not need to keep editing login_client.py file and future updates should not change their API key setting.
