### PR TITLE
[upd] Ignore if '.apps.googleusercontent.com' entered in API Id string in add-on settings

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.youtube" name="YouTube" version="5.1.20.4" provider-name="bromix">
+<addon id="plugin.video.youtube" name="YouTube" version="5.1.20.5" provider-name="bromix">
 	<requires>
 		<import addon="xbmc.python" version="2.1.0"/>
 	</requires>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+5.1.20.5 (2016-03-20)
+[upd] Ignore if '.apps.googleusercontent.com' entered in API Id string in add-on settings
+
 5.1.20.4 (2016-03-05)
 [add] API Key in add-on settings
 [upd] All string.po for new API Key functionality. New entries in language string.po files not translated from English.

--- a/resources/lib/youtube/client/login_client.py
+++ b/resources/lib/youtube/client/login_client.py
@@ -9,7 +9,7 @@ from resources.lib.youtube.youtube_exceptions import LoginException
 
 addon = xbmcaddon.Addon()
 api_key = addon.getSetting('youtube.api.key')
-api_id = addon.getSetting('youtube.api.id')
+api_id = addon.getSetting('youtube.api.id').replace('.apps.googleusercontent.com', '')
 api_secret = addon.getSetting('youtube.api.secret')
 
 # Kodi 17 support by Uukrul


### PR DESCRIPTION
[upd] Ignore if '.apps.googleusercontent.com' entered in API Id string in add-on settings.

In login_client.py:

Replace old code: api_id = addon.getSetting('youtube.api.id')
With new code: api_id = addon.getSetting('youtube.api.id').replace('.apps.googleusercontent.com', '')
