### PR TITLE
add mpeg-dash support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/.settings
+/.project
+/.pydevproject
+*.pyc
+*.pyo
+/.idea

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -39,7 +39,15 @@ msgctxt "#30002"
 msgid "Password"
 msgstr ""
 
-#empty strings from id 30003 to 30008
+#empty strings from id 30003 to 30006
+
+msgctxt "#30007"
+msgid "Use MPEG-DASH"
+msgstr ""
+
+msgctxt "#30008"
+msgid "Configure MPEG-DASH InputStream Client"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Always ask for the video quality"

--- a/resources/lib/kodion/constants/const_settings.py
+++ b/resources/lib/kodion/constants/const_settings.py
@@ -6,6 +6,7 @@ SEARCH_SIZE = 'kodion.search.size'  # (int)
 CACHE_SIZE = 'kodion.cache.size'  # (int)
 VIDEO_QUALITY = 'kodion.video.quality'  # (int)
 VIDEO_QUALITY_ASK = 'kodion.video.quality.ask'  # (bool)
+USE_DASH = 'kodion.video.quality.mpd'  # (bool)
 SETUP_WIZARD = 'kodion.setup_wizard'  # (bool)
 
 SUPPORT_ALTERNATIVE_PLAYER = 'kodion.support.alternative_player'  # (bool)

--- a/resources/lib/kodion/impl/abstract_settings.py
+++ b/resources/lib/kodion/impl/abstract_settings.py
@@ -93,4 +93,7 @@ class AbstractSettings(object):
     def is_support_alternative_player_enabled(self):
         return self.get_bool(constants.setting.SUPPORT_ALTERNATIVE_PLAYER, False)
 
+    def use_dash(self):
+        return self.get_bool(constants.setting.USE_DASH, False)
+
     pass

--- a/resources/lib/kodion/impl/xbmc/xbmc_items.py
+++ b/resources/lib/kodion/impl/xbmc/xbmc_items.py
@@ -20,6 +20,12 @@ def to_video_item(context, video_item):
     if video_item.get_context_menu() is not None:
         item.addContextMenuItems(video_item.get_context_menu(), replaceItems=video_item.replace_context_menu())
         pass
+    if video_item.use_dash():
+        item.setProperty('inputstream.mpd.license_type', '')
+        item.setProperty('inputstream.mpd.license_key', '')
+        item.setProperty('inputstreamaddon', 'inputstream.mpd')
+    else:
+        item.setProperty('inputstreamaddon', '')
 
     item.setProperty(u'IsPlayable', u'true')
 

--- a/resources/lib/kodion/items/video_item.py
+++ b/resources/lib/kodion/items/video_item.py
@@ -26,6 +26,7 @@ class VideoItem(BaseItem):
         self._studio = None
         self._artist = None
         self._play_count = None
+        self._uses_dash = None
         pass
 
     def set_play_count(self, play_count):
@@ -199,4 +200,9 @@ class VideoItem(BaseItem):
     def set_track_number(self, track_number):
         self._track_number = track_number
         pass
-    pass
+
+    def set_use_dash(self, value=True):
+        self._uses_dash = value
+
+    def use_dash(self):
+        return self._uses_dash is True and 'manifest/dash' in self.get_uri()

--- a/resources/lib/youtube/helper/utils.py
+++ b/resources/lib/youtube/helper/utils.py
@@ -157,6 +157,9 @@ def update_video_infos(provider, context, video_id_dict, playlist_item_id_dict=N
 
         snippet = yt_item['snippet']  # crash if not conform
 
+        # set uses_dash
+        video_item.set_use_dash(context.get_settings().use_dash())
+
         # set the title
         video_item.set_title(snippet['title'])
 

--- a/resources/lib/youtube/helper/video_info.py
+++ b/resources/lib/youtube/helper/video_info.py
@@ -318,6 +318,12 @@ class VideoInfo(object):
         '251': {'container': 'webm',
                 'dash/audio': True,
                 'audio': {'bitrate': 160, 'encoding': 'opus'}},
+        # === DASH adaptive
+        '9999': {'container': 'mpd',
+                 'dash/audio': True,
+                 'dash/video': True,
+                 'audio': {'bitrate': 0, 'encoding': ''},
+                 'video': {'height': 0, 'encoding': ''}}
     }
 
     def __init__(self, context, access_token='', language='en-US'):
@@ -521,10 +527,7 @@ class VideoInfo(object):
                    'Accept-Language': 'en-US,en;q=0.8,de;q=0.6'}
         params = {'video_id': video_id,
                   'hl': self._language,
-                  'ps': 'leanback',
-                  'el': 'leanback',
-                  'width': '1920',
-                  'height': '1080',
+                  'eurl': 'https://youtube.googleapis.com/v/' + video_id,
                   'ssl_stream': '1',
                   'c': 'TVHTML5',
                   'cver': '4',
@@ -533,6 +536,12 @@ class VideoInfo(object):
                   'cbrver': '40.0.2214.115',
                   'cos': 'Windows',
                   'cosver': '6.1'}
+        if not self._context.get_settings().use_dash():
+            params.update({'ps': 'leanback',
+                           'el': 'leanback',
+                           'width': '1920',
+                           'height': '1080'})
+
         if self._access_token:
             params['access_token'] = self._access_token
             pass
@@ -599,6 +608,16 @@ class VideoInfo(object):
                 pass
             pass
         """
+
+        if self._context.get_settings().use_dash():
+            mpd_url = params.get('dashmpd', None)
+            if mpd_url:
+                video_stream = {'url': mpd_url,
+                                'title': meta_info['video'].get('title', ''),
+                                'meta': meta_info}
+                video_stream.update(self.FORMAT.get('9999'))
+                stream_list.append(video_stream)
+                return stream_list
 
         # extract streams from map
         url_encoded_fmt_stream_map = params.get('url_encoded_fmt_stream_map', '')

--- a/resources/lib/youtube/provider.py
+++ b/resources/lib/youtube/provider.py
@@ -480,6 +480,11 @@ class Provider(kodion.AbstractProvider):
         result.extend(v3.response_to_items(self, context, json_data))
         return result
 
+    @kodion.RegisterProviderPath('^/config/mpd/$')
+    def configure_mpd_inputstream(self, context, query):
+        from xbmcaddon import Addon
+        Addon(id='inputstream.mpd').openSettings()
+
     def on_root(self, context, re_match):
         """
         Support old YouTube url calls, but also log a deprecation warnings.

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,8 +4,10 @@
     <category label="30000">
 
         <!-- kodion Visual -->
-        <setting id="kodion.video.quality" type="enum" label="30010" enable="eq(1,false)" lvalues="30016|30017|30011|30012|30013" default="3" />
-        <setting id="kodion.video.quality.ask" type="bool" label="30009" default="false" />
+        <setting id="kodion.video.quality" type="enum" label="30010" enable="eq(1,false) + eq(2,false)" lvalues="30016|30017|30011|30012|30013" default="3"/>
+        <setting id="kodion.video.quality.ask" type="bool" label="30009" default="false" enable="eq(1,false)"/>
+        <setting id="kodion.video.quality.mpd" type="bool" label="30007" default="false" enable="System.HasAddon(inputstream.mpd)"/>
+        <setting id="kodion.video.quality.mpd.configure" type="action" label="30008" enable="System.HasAddon(inputstream.mpd)" option="close" action="RunPlugin(plugin://plugin.video.youtube/config/mpd/)"/>
         <setting id="youtube.playlist.watchlater.autoremove" type="bool" label="30515" default="true" />
         <setting type="sep" />
         <setting id="kodion.fanart.show" type="bool" label="30021" default="true"/>


### PR DESCRIPTION
- requires latest Kodi nightlies
- requires inputstream.mpd v1.1.0

Dash settings are only enabled if inputstream.mpd is present, which should only be true in Kodi 17 at the present so this should not cause any issues for older versions. Other than users seeing it grayed out and unavailable to them.
