### PR TITLE
Watch Later, using methods mentioned in forum

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -7,6 +7,14 @@
 		<provides>video</provides>
 	</extension>
 	<extension point="xbmc.addon.metadata">
+        <news>
+- Added MPEG-DASH support for Kodi 17 w/ inputstream.mpd Add-on
+- Added optional Watch Later custom playlist to Settings -> Folders
+        </news>
+        <assets>
+            <icon>icon.png</icon>
+            <fanart>fanart.jpg</fanart>
+        </assets>
         <summary lang="en">Plugin for YouTube</summary>
         <description lang="en">YouTube is one of the biggest video-sharing websites of the world.</description>
 		<summary lang="de">Plugin für YouTube</summary>

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -155,8 +155,12 @@ msgctxt "#30036"
 msgid "Support alternative player"
 msgstr ""
 
+msgctxt "#30037"
+msgid "Custom Watch Later Playlist ID"
+msgstr ""
+
 #Kodion Common
-#empty strings from id 30037 to 30099
+#empty strings from id 30038 to 30099
 
 msgctxt "#30100"
 msgid "Favorites"

--- a/resources/lib/kodion/impl/xbmc/info_labels.py
+++ b/resources/lib/kodion/impl/xbmc/info_labels.py
@@ -86,6 +86,10 @@ def _process_list_value(info_labels, name, param):
     pass
 
 
+def _process_mediatype(info_labels, name, param):
+    info_labels[name] = param
+
+
 def create_from_item(context, base_item):
     info_labels = {}
 
@@ -115,6 +119,9 @@ def create_from_item(context, base_item):
 
     # Video
     if isinstance(base_item, VideoItem):
+        # mediatype
+        _process_mediatype(info_labels, 'mediatype', base_item.get_mediatype())
+
         # play count
         _process_int_value(info_labels, 'playcount', base_item.get_play_count())
 

--- a/resources/lib/kodion/items/video_item.py
+++ b/resources/lib/kodion/items/video_item.py
@@ -27,6 +27,7 @@ class VideoItem(BaseItem):
         self._artist = None
         self._play_count = None
         self._uses_dash = None
+        self._mediatype = None
         pass
 
     def set_play_count(self, play_count):
@@ -206,3 +207,12 @@ class VideoItem(BaseItem):
 
     def use_dash(self):
         return self._uses_dash is True and 'manifest/dash' in self.get_uri()
+
+    def set_mediatype(self, mediatype):
+        self._mediatype = mediatype
+        pass
+
+    def get_mediatype(self):
+        if self._mediatype not in ['video', 'movie', 'tvshow', 'season', 'episode', 'musicvideo']:
+            self._mediatype = 'video'
+        return self._mediatype

--- a/resources/lib/youtube/helper/utils.py
+++ b/resources/lib/youtube/helper/utils.py
@@ -160,6 +160,9 @@ def update_video_infos(provider, context, video_id_dict, playlist_item_id_dict=N
         # set uses_dash
         video_item.set_use_dash(context.get_settings().use_dash())
 
+        # set mediatype
+        video_item.set_mediatype('episode')  # using episode since all setContent is currently episode as well
+
         # set the title
         video_item.set_title(snippet['title'])
 

--- a/resources/lib/youtube/helper/yt_context_menu.py
+++ b/resources/lib/youtube/helper/yt_context_menu.py
@@ -94,6 +94,9 @@ def append_rate_video(context_menu, provider, context, video_id, refresh_contain
 
 
 def append_watch_later(context_menu, provider, context, playlist_id, video_id):
+    cplid = context.get_settings().get_string('youtube.folder.watch_later.playlist', '').strip()
+    if cplid:
+        playlist_id = cplid
     playlist_path = kodion.utils.create_path('channel', 'mine', 'playlist', playlist_id)
     if playlist_id and playlist_path != context.get_path():
         context_menu.append((context.localize(provider.LOCAL_MAP['youtube.watch_later']),

--- a/resources/lib/youtube/provider.py
+++ b/resources/lib/youtube/provider.py
@@ -560,6 +560,8 @@ class Provider(kodion.AbstractProvider):
         # subscriptions
         if self.is_logged_in():
             playlists = resource_manager.get_related_playlists(channel_id='mine')
+            if playlists.has_key('watchLater'):
+                playlists['watchLater'] = ' WL'
 
             # my channel
             if settings.get_bool('youtube.folder.my_channel.show', True):

--- a/resources/lib/youtube/provider.py
+++ b/resources/lib/youtube/provider.py
@@ -402,9 +402,11 @@ class Provider(kodion.AbstractProvider):
 
                 # second: remove video from 'Watch Later' playlist
                 if context.get_settings().get_bool('youtube.playlist.watchlater.autoremove', True):
-                    playlist_item_id = client.get_playlist_item_id_of_video_id(playlist_id='WL', video_id=video_id)
+                    cplid = context.get_settings().get_string('youtube.folder.watch_later.playlist', '').strip()
+                    playlist_id = cplid if cplid else 'WL'
+                    playlist_item_id = client.get_playlist_item_id_of_video_id(playlist_id=playlist_id, video_id=video_id)
                     if playlist_item_id:
-                        json_data = client.remove_video_from_playlist('WL', playlist_item_id)
+                        json_data = client.remove_video_from_playlist(playlist_id, playlist_item_id)
                         if not v3.handle_error(self, context, json_data):
                             return False
                         pass

--- a/resources/lib/youtube/provider.py
+++ b/resources/lib/youtube/provider.py
@@ -561,7 +561,8 @@ class Provider(kodion.AbstractProvider):
         if self.is_logged_in():
             playlists = resource_manager.get_related_playlists(channel_id='mine')
             if playlists.has_key('watchLater'):
-                playlists['watchLater'] = ' WL'
+                cplid = settings.get_string('youtube.folder.watch_later.playlist', '').strip()
+                playlists['watchLater'] = ' %s' % cplid if cplid else ' WL'
 
             # my channel
             if settings.get_bool('youtube.folder.my_channel.show', True):

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -23,6 +23,8 @@
         <setting id="youtube.folder.popular_right_now.show" type="bool" label="30513" default="true"/>
         <setting id="youtube.folder.my_channel.show" type="bool" label="30507" default="true"/>
         <setting id="youtube.folder.watch_later.show" type="bool" label="30107" default="true"/>
+        <setting id="youtube.folder.watch_later.playlist" type="text" label="30037" enable="eq(-1,true)"
+                 visible="eq(-1,true)" default=""/>
         <setting id="youtube.folder.liked_videos.show" type="bool" label="30508" default="true"/>
         <setting id="youtube.folder.disliked_videos.show" type="bool" label="30538" default="true"/>
         <setting id="youtube.folder.history.show" type="bool" label="30509" default="true"/>


### PR DESCRIPTION
Optional custom playlist id for watch later added to Settings -> Folders
If no custom playlist id is provided will use ' WL' for watch later playlist retrieval 
