### PR TITLE
Add Maintenance to Settings

### DIFF
--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -483,3 +483,35 @@ msgstr ""
 msgctxt "#30551"
 msgid "Recommendations"
 msgstr ""
+
+msgctxt "#30552"
+msgid "Maintenance"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Delete function cache database"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Delete search history database"
+msgstr ""
+
+msgctxt "#30555"
+msgid "Clear function cache"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Clear search history"
+msgstr ""
+
+msgctxt "#30557"
+msgid "function cache"
+msgstr ""
+
+msgctxt "#30558"
+msgid "search history"
+msgstr ""
+
+msgctxt "#30559"
+msgid "Delete settings.xml"
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -58,4 +58,15 @@
         <setting id="youtube.api.id" type="text" label="30202" enable="eq(-3,true)" default="861556708454-d6dlm3lh05idd8npek18k6be8ba3oc68"/>
         <setting id="youtube.api.secret" type="text" label="30203" enable="eq(-4,true)" default="SboVhoG9s0rNafixCSGGKXAT"/>
     </category>
+
+    <!-- Maintenance -->
+    <category label="30552">
+        <setting id="kodion.maintain.clear.func" type="action" label="30555" action="RunPlugin(plugin://plugin.video.youtube/maintain/function_cache/clear/)"/>
+        <setting id="kodion.maintain.clear.search" type="action" label="30556" action="RunPlugin(plugin://plugin.video.youtube/maintain/search_cache/clear/)"/>
+        <setting type="sep" />
+        <setting id="kodion.maintain.delete.func" type="action" label="30553" action="RunPlugin(plugin://plugin.video.youtube/maintain/function_cache/delete/)"/>
+        <setting id="kodion.maintain.delete.search" type="action" label="30554" action="RunPlugin(plugin://plugin.video.youtube/maintain/search_cache/delete/)"/>
+        <setting type="sep" />
+        <setting id="kodion.maintain.delete.settings" type="action" label="30559" action="RunPlugin(plugin://plugin.video.youtube/maintain/settings_xml/delete/)"/>
+    </category>
 </settings>


### PR DESCRIPTION
- Allow users to clear or delete caches/settings.xml from Settings, simplifies resolution of database issues and user maintenance
- Adds 'Clear function cache', 'Clear search history', 'Delete function cache database', 'Delete search history database' and 'Delete settings.xml' to 'Maintenance' section in Settings
