### PR TITLE
Optional URLResolver (Debrid) support

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -2,6 +2,7 @@
 <addon id="plugin.video.youtube" name="YouTube" version="5.3.0~alpha3" provider-name="h0d3nt3uf3l, bromix">
 	<requires>
 		<import addon="xbmc.python" version="2.1.0"/>
+        <import addon="script.module.urlresolver" optional="true"/>
 	</requires>
 	<extension point="xbmc.python.pluginsource" library="default.py">
 		<provides>video</provides>

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -162,8 +162,16 @@ msgctxt "#30038"
 msgid "Custom History Playlist ID"
 msgstr ""
 
+msgctxt "#30039"
+msgid "Enable URLResolver (Debrid) support"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Configure URLResolver"
+msgstr ""
+
 #Kodion Common
-#empty strings from id 30039 to 30099
+#empty strings from id 30041 to 30099
 
 msgctxt "#30100"
 msgid "Favorites"

--- a/resources/lib/kodion/constants/const_settings.py
+++ b/resources/lib/kodion/constants/const_settings.py
@@ -7,6 +7,7 @@ CACHE_SIZE = 'kodion.cache.size'  # (int)
 VIDEO_QUALITY = 'kodion.video.quality'  # (int)
 VIDEO_QUALITY_ASK = 'kodion.video.quality.ask'  # (bool)
 USE_DASH = 'kodion.video.quality.mpd'  # (bool)
+DEBRID_SUPPORT = 'kodion.support.urlresolver_debrid'  # (bool)
 SUBTITLE_LANGUAGES = 'kodion.subtitle.languages'  # (int)
 SETUP_WIZARD = 'kodion.setup_wizard'  # (bool)
 

--- a/resources/lib/kodion/impl/abstract_settings.py
+++ b/resources/lib/kodion/impl/abstract_settings.py
@@ -101,3 +101,6 @@ class AbstractSettings(object):
 
     def requires_dual_login(self):
         return self.get_bool('youtube.folder.my_subscriptions.show', True)
+
+    def use_debrid(self):
+        return self.get_bool(constants.setting.DEBRID_SUPPORT, False)

--- a/resources/lib/youtube/provider.py
+++ b/resources/lib/youtube/provider.py
@@ -483,9 +483,16 @@ class Provider(kodion.AbstractProvider):
         result.extend(v3.response_to_items(self, context, json_data))
         return result
 
-    @kodion.RegisterProviderPath('^/config/mpd/$')
-    def configure_mpd_inputstream(self, context, query):
-        xbmcaddon.Addon(id='inputstream.mpd').openSettings()
+    @kodion.RegisterProviderPath('^/config/(?P<switch>.*)/$')
+    def configure_mpd_inputstream(self, context, re_match):
+        switch = re_match.group('switch')
+        if switch == 'mpd':
+            xbmcaddon.Addon(id='inputstream.mpd').openSettings()
+        elif switch == 'urlresolver':
+            import urlresolver
+            urlresolver.display_settings()
+        else:
+            return False
 
     @kodion.RegisterProviderPath('^/maintain/(?P<maint_type>.*)/(?P<action>.*)/$')
     def maintenance_actions(self, context, re_match):

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -7,7 +7,7 @@
         <setting id="kodion.video.quality" type="enum" label="30010" enable="eq(1,false)" lvalues="30016|30017|30011|30012" default="3"/>
         <setting id="kodion.video.quality.ask" type="bool" label="30009" default="false"/>
         <setting id="kodion.video.quality.mpd" type="bool" label="30007" default="false" enable="System.HasAddon(inputstream.mpd)"/>
-        <setting id="kodion.video.quality.mpd.configure" type="action" label="30008" enable="System.HasAddon(inputstream.mpd)" option="close" action="RunPlugin(plugin://plugin.video.youtube/config/mpd/)"/>
+        <setting id="kodion.video.quality.mpd.configure" type="action" label="30008" enable="eq(-1,true)" visible="eq(-1,true)" option="close" action="RunPlugin(plugin://plugin.video.youtube/config/mpd/)"/>
         <setting id="kodion.subtitle.languages" type="enum" label="30560" lvalues="30561|30562|30563|30564|30565|30566" default="0"/>
         <setting id="youtube.playlist.watchlater.autoremove" type="bool" label="30515" default="true" />
         <setting type="sep" />
@@ -40,6 +40,8 @@
 
     <category label="30031">
         <setting id="kodion.support.alternative_player" type="bool" label="30036" default="false"/>
+        <setting id="kodion.support.urlresolver_debrid" type="bool" label="30039" default="false" enable="System.HasAddon(script.module.urlresolver)"/>
+        <setting id="kodion.urlresolver.configure" type="action" label="30040"  option="close" enable="eq(-1,true)" visible="eq(-1,true)" action="RunPlugin(plugin://plugin.video.youtube/config/urlresolver/)"/>
         <setting id="youtube.view.description.show_channel_name" type="bool" label="30541" default="true"/>
         <setting type="sep" />
         <setting id="kodion.view.override" type="bool" label="30026" default="false"/>


### PR DESCRIPTION
- add 'Enable URLResolver (Debrid) support' and 'Configure URLResolver' to Settings -> Advanced
- these settings are only enabled/visible if script.module.urlresolver is installed
- Enabling this will attempt to use URLResolver to resolve the youtube url. If the resolution failed or resulted in a 'plugin://' url, playback is handled like normal

Requirements for this option:
- 'script.module.urlresolver' is installed
- an account with a Debrid service that supports YouTube and has a resolver available in URLResolver
- URLResolver and resolver(s) properly configured

This option is only useful for users that meet these requirements, and will enable >720p without mpeg-dash for these users
All configuration other than the enabling of the feature itself is handled by URLResolver

Special thanks to @mortael for testing/confirming these results and providing us a screenshot of the results seen below:
![URLResolver Real-Debrid Results](http://i.imgur.com/FId7GlI.png)
