### PR TITLE
move function cache clearing to sign in process

### DIFF
--- a/resources/lib/youtube/helper/yt_login.py
+++ b/resources/lib/youtube/helper/yt_login.py
@@ -115,6 +115,9 @@ def process(mode, provider, context, re_match, needs_tv_login=True):
         #     expires_in = expires_in_kodi
         #     pass
 
+        # we clear the cache, so none cached data of an old account will be displayed.
+        context.get_function_cache().clear()
+
         major_version = context.get_system_version().get_version()[0]
         context.get_settings().set_int('youtube.login.version', major_version)
 

--- a/resources/lib/youtube/provider.py
+++ b/resources/lib/youtube/provider.py
@@ -107,7 +107,7 @@ class Provider(kodion.AbstractProvider):
             # reset access_token
             access_manager.update_access_token('')
             # we clear the cache, so none cached data of an old account will be displayed.
-            context.get_function_cache().clear()
+            # context.get_function_cache().clear()
             # reset the client
             self._client = None
             pass


### PR DESCRIPTION
- cache should be cleared on both sign-in and out process now

fixes
- function cache being constantly cleared if not signed in
- logged out users will now use function cache like signed in users, this should improve quota usage in general